### PR TITLE
Fix: Correct Condition for Template Name Length in FindTemplateByName

### DIFF
--- a/internal/variables/variables.go
+++ b/internal/variables/variables.go
@@ -16,7 +16,7 @@ func GetIssueInput(owner string, repo string, issueNumber int) map[string]any {
 }
 
 func FindTemplateByName(templates []types.IssueTemplate, name string) *types.IssueTemplate {
-	if len(name) > 0 {
+	if len(name) == 0 {
 		return nil
 	}
 	m := map[graphql.String]types.IssueTemplate{}


### PR DESCRIPTION
# Issue

- Close #1 

# Contents

updates the conditional check in the FindTemplateByName function.
Previously, the function returned nil if the length of the template name was greater than zero, which prevented finding any template by a non-empty name.
The condition is now changed to return nil only if the template name length is zero, ensuring correct behavior when searching for templates by name.

This change allows the function to return the correct template when a valid name is provided.