### PR TITLE
Implement new flag --browse

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/cli/go-gh/v2/pkg/api"
@@ -83,7 +82,7 @@ func CloneIssue(ctx context.Context, c *cli.Command) error {
 			err = client.Mutate("UpdateProjectV2ItemFieldValue", &updateMutation, input)
 			if err != nil {
 				fieldName := projectField.ProjectV2ItemFieldValueCommon.Field.ProjectV2FieldCommon.Name
-				log.Printf("Fail to update project field[%s]: %v\n", fieldName, err)
+				fmt.Printf("Fail to update project field[%s]: %v\n", fieldName, err)
 				continue
 			}
 		}
@@ -94,5 +93,14 @@ func CloneIssue(ctx context.Context, c *cli.Command) error {
 	fmt.Printf("Title: %s\n", createMutation.CreateIssue.Issue.Title)
 	fmt.Printf("URL:   %s\n", createMutation.CreateIssue.Issue.Url)
 	fmt.Println("----------------------------------------------------------------------------")
+
+	if c.Bool("browse") {
+		clonedIssueURL := string(createMutation.CreateIssue.Issue.Url)
+		fmt.Println("") // line break only
+		fmt.Printf("opening %s in your browser.\n", clonedIssueURL)
+		if err := browse(clonedIssueURL); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+func open(url string) error {
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		args = []string{"open"}
+	case "windows":
+		args = []string{"cmd", "/c", "start"}
+	default:
+		args = []string{"xdg-open"}
+	}
+	cmd := exec.Command(args[0], append(args[1:], url)...)
+	return cmd.Start()
+}
+
+func browse(url string) error {
+	// wait a little
+	time.Sleep(100 * time.Millisecond)
+
+	_, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf(" couldn't open %s", url)
+	}
+	if err := open(url); err != nil {
+		return fmt.Errorf(" couldn't open %s", url)
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 		Version: versions.AppVersion,
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "template", Aliases: []string{"t"}, Usage: "Issue Template Name"},
+			&cli.BoolFlag{Name: "browse", Aliases: []string{"b"}, Usage: "Open cloned issue in your browser", HideDefault: true},
 		},
 		Arguments: []cli.Argument{
 			&cli.StringArg{Name: "url"},


### PR DESCRIPTION
## Feature

Open cloned issue url in your browser when specified `--browse` flag.

### commit
- [feat: new flag --browse open cloned issue in browser](https://github.com/muleyuck/gh-issue-clone/commit/95dddd859daa6ec3ea981c67ead4223292b8b897)